### PR TITLE
V1.2.4 bugfixes

### DIFF
--- a/examples/MD_DS3231_Test/MD_DS3231_Test.ino
+++ b/examples/MD_DS3231_Test/MD_DS3231_Test.ino
@@ -11,7 +11,7 @@
 
 void setup()
 {
-  Serial.begin(57600);
+  Serial.begin(38400);
   usage();
   RTC.setAlarm1Callback(cbAlarm1);
   RTC.setAlarm2Callback(cbAlarm2);

--- a/src/MD_DS3231.cpp
+++ b/src/MD_DS3231.cpp
@@ -356,11 +356,12 @@ boolean MD_DS3231::packAlarm(uint8_t entryPoint)
         bufRTC[ADDR_MIN] = bin2BCD(m);
         if (mode12)     // 12 hour clock
         {
-          uint8_t	hour = bin2BCD(h);
-
-          pm = (hour > 12);
-          if (pm) hour -= 12;
-          bufRTC[ADDR_HR] = bin2BCD(hour);
+          if (h > 12) {
+            h -= 12;
+            pm = true;
+          }
+          
+          bufRTC[ADDR_HR] = bin2BCD(h);
           if (pm) bufRTC[ADDR_CTL_PM] |= CTL_PM;
           bufRTC[ADDR_CTL_12H] |= CTL_12H;
         }
@@ -412,8 +413,11 @@ boolean MD_DS3231::writeTime(void)
   bufRTC[ADDR_MIN] = bin2BCD(m);
   if (mode12)     // 12 hour clock
   {
-    pm = (h > 12);
-    if (pm) h -= 12;
+    if (h > 12) {
+      h -= 12;
+      pm = true;
+    }
+    
     bufRTC[ADDR_HR] = bin2BCD(h);
     if (pm) bufRTC[ADDR_CTL_PM] |= CTL_PM;
     bufRTC[ADDR_CTL_12H] |= CTL_12H;

--- a/src/MD_DS3231.cpp
+++ b/src/MD_DS3231.cpp
@@ -367,7 +367,7 @@ boolean MD_DS3231::packAlarm(uint8_t entryPoint)
         else
           bufRTC[ADDR_HR] = bin2BCD(h);
 
-        if (dow == 0) // signal that this is a date, not day
+        if (dow != 0) // signal that this is a date, not day
         {
           bufRTC[ADDR_DAY] = bin2BCD(dow);
           bufRTC[ADDR_CTL_DYDT] |= CTL_DYDT; 


### PR DESCRIPTION
Hi,

This pull request contains some minor bugfixes
 * In `packAlarm`, the DD/DY condition was reversed
 * `packAlarm` BCD encoded the hour to early
 * When using 12H clock mode, `pm` indicator was overwritten by `packAlarm` and `writeTime`. Additionally, can now use both 5PM and 17 format