### PR TITLE
Hex trim

### DIFF
--- a/src/MD_DS3231.cpp
+++ b/src/MD_DS3231.cpp
@@ -161,10 +161,10 @@ boolean MD_DS3231::setAlarm1Type(almType_t almType)
 
   int16_t alm1Type = static_cast<int16_t>(almType);
   // mask in the new data = clear the bit and then set current value
-  bufRTC[0] = (bufRTC[0] & 0x7f) | (bitRead(alm1Type, 0) << 7);
-  bufRTC[1] = (bufRTC[1] & 0x7f) | (bitRead(alm1Type, 1) << 7);
-  bufRTC[2] = (bufRTC[2] & 0x7f) | (bitRead(alm1Type, 2) << 7);
-  bufRTC[3] = (bufRTC[3] & 0x3f) | (bitRead(alm1Type, 3) << 7) | (bitRead(alm1Type, 4) << 6);
+  for(uint8_t i = 0; i < 4; i++) {
+    bitWrite(bufRTC[i], 7, bitRead(alm1Type, i));
+  }
+  bitWrite(bufRTC[3], 6, bitRead(alm1Type, 4));
 
   // write the data back out
   return(writeDevice(ADDR_ALM1, bufRTC, 4) == 4);
@@ -194,9 +194,10 @@ boolean MD_DS3231::setAlarm2Type(almType_t almType)
 
   int16_t alm2Type = static_cast<int16_t>(almType);
   // mask in the new data = clear the bit and then set current value
-  bufRTC[0] = (bufRTC[0] & 0x7f) | (bitRead(alm2Type, 0) << 7);
-  bufRTC[1] = (bufRTC[1] & 0x7f) | (bitRead(alm2Type, 1) << 7);
-  bufRTC[2] = (bufRTC[2] & 0x7f) | (bitRead(alm2Type, 2) << 7) | (bitRead(alm2Type, 3) << 6);;
+  for(uint8_t i = 0; i < 3; i++) {
+    bitWrite(bufRTC[i], 7, bitRead(alm2Type, i));
+  }
+  bitWrite(bufRTC[2], 6, bitRead(alm2Type, 3));
 
   // write the data back out
   return(writeDevice(ADDR_ALM2, bufRTC, 3) == 3);  

--- a/src/MD_DS3231.cpp
+++ b/src/MD_DS3231.cpp
@@ -183,10 +183,11 @@ boolean MD_DS3231::setAlarm1Type(almType_t almType)
   readDevice(ADDR_ALM1, bufRTC, 4);
 
   int16_t alm1Type = static_cast<int16_t>(almType);
-  // mask in the new data = clear the bit and then set current value
+  // split each bit of almType to the seventh bit
   for(uint8_t i = 0; i < 4; i++) {
     bitWrite(bufRTC[i], 7, bitRead(alm1Type, i));
   }
+  // set the D bit
   bitWrite(bufRTC[3], 6, bitRead(alm1Type, 4));
 
   // write the data back out
@@ -199,7 +200,7 @@ almType_t MD_DS3231::getAlarm1Type(void)
   // read the current data into the buffer
   if(readDevice(ADDR_ALM1, bufRTC, 4) != 4) return DS3231_ALM_ERROR;
 
-  // create a value with bit 0=M1, 1=M2, 2=M3, 3=M4, 4=D
+  // create a value with bits 0=M1, 1=M2, 2=M3, 3=M4, 4=D
   uint16_t m = 0;
   for(uint8_t i = 0; i < 4; i++) {
     m |= (bufRTC[i] & 0x80) >> (7 - i);  
@@ -216,10 +217,11 @@ boolean MD_DS3231::setAlarm2Type(almType_t almType)
   readDevice(ADDR_ALM2, bufRTC, 3);
 
   int16_t alm2Type = static_cast<int16_t>(almType);
-  // mask in the new data = clear the bit and then set current value
+  // split each bit of almType to the seventh bit
   for(uint8_t i = 0; i < 3; i++) {
     bitWrite(bufRTC[i], 7, bitRead(alm2Type, i));
   }
+  // set the D bit
   bitWrite(bufRTC[2], 6, bitRead(alm2Type, 3));
 
   // write the data back out
@@ -232,7 +234,7 @@ almType_t MD_DS3231::getAlarm2Type(void)
   // read the current data into the buffer
   if(readDevice(ADDR_ALM2, bufRTC, 3) != 3) return DS3231_ALM_ERROR;
 
-  // create a value with bit 0=M2, 2=M3, 3=M4
+  // create a value with bits 0=M2, 1=M3, 2=M4, 4=D
   uint8_t m = 0;
   for(uint8_t i = 0; i < 3; i++) {
     m |= (bufRTC[i] & 0x80) >> (7 - i);  

--- a/src/MD_DS3231.cpp
+++ b/src/MD_DS3231.cpp
@@ -491,10 +491,12 @@ uint8_t MD_DS3231::calcDoW(uint16_t yyyy, uint8_t mm, uint8_t dd)
 // This algorithm good for dates  yyyy > 1752 and  1 <= mm <= 12
 // Returns dow  01 - 07, 01 = Sunday
 {
-  static int t[] = {0, 3, 2, 5, 0, 3, 5, 1, 4, 6, 2, 4};
+  static const uint8_t ts[] PROGMEM = {0, 3, 2, 5, 0, 3, 5, 1, 4, 6, 2, 4};
+  uint8_t t;
+  memcpy_P(&t, &ts[mm - 1], 1);
     
   yyyy -= mm < 3;
-  return ((yyyy + yyyy/4 - yyyy/100 + yyyy/400 + t[mm-1] + dd) % 7) + 1;
+  return ((yyyy + yyyy/4 - yyyy/100 + yyyy/400 + t + dd) % 7) + 1;
 }
 
 ATTR_USE

--- a/src/MD_DS3231.cpp
+++ b/src/MD_DS3231.cpp
@@ -460,7 +460,6 @@ uint8_t MD_DS3231::calcDoW(uint16_t yyyy, uint8_t mm, uint8_t dd)
   return ((yyyy + yyyy/4 - yyyy/100 + yyyy/400 + t[mm-1] + dd) % 7) + 1;
 }
 
-#if ENABLE_TEMP_COMP
 ATTR_USE
 float MD_DS3231::readTempRegister()
 {
@@ -469,7 +468,6 @@ float MD_DS3231::readTempRegister()
     
   return(bufRTC[0] + ((bufRTC[1] >> 6) * 0.25));
 }
-#endif
 
 ATTR_USE
 boolean MD_DS3231::control(codeRequest_t item, uint8_t value)

--- a/src/MD_DS3231.cpp
+++ b/src/MD_DS3231.cpp
@@ -100,11 +100,8 @@ ATTR_USE
 uint8_t MD_DS3231::writeDevice(uint8_t addr, uint8_t* buf, uint8_t len)
 {
   Wire.beginTransmission(DS3231_ID);
-  Wire.write(addr);       // set register address                  
-  for (uint8_t i=0; i<len; i++) // Send x data from given address upwards...
-  {
-    Wire.write(buf[i]);         // ... and send it from buffer
-  }
+  Wire.write(addr);       // set register address 
+  Wire.write(buf, len);   // ... and send it from buffer                 
   Wire.endTransmission();
 
   return(len);

--- a/src/MD_DS3231.cpp
+++ b/src/MD_DS3231.cpp
@@ -19,7 +19,9 @@
 
 // #define ATTR_USE
 
+#if ENABLE_RTC_INSTANCE
 class MD_DS3231 RTC;  // one instance created when library is included
+#endif
 
 // Useful definitions
 #define DS3231_ID 0x68  // I2C/TWI device address, coded into the device

--- a/src/MD_DS3231.cpp
+++ b/src/MD_DS3231.cpp
@@ -11,14 +11,6 @@
 #include <Wire.h>
 #include "MD_DS3231.h"
 
-#pragma GGC push_options
-
-#pragma GCC optimize ("no-dce")
-#pragma GCC optimize ("no-tree-dce")
-#define ATTR_USE __attribute__ ((used))
-
-// #define ATTR_USE
-
 #if ENABLE_RTC_INSTANCE
 class MD_DS3231 RTC;  // one instance created when library is included
 #endif
@@ -89,7 +81,6 @@ uint8_t bufRTC[MAX_BUF];
 
 
 // Interface functions for the RTC device
-ATTR_USE
 uint8_t MD_DS3231::readDevice(uint8_t addr, uint8_t* buf, uint8_t len)
 {
   Wire.beginTransmission(DS3231_ID);
@@ -107,7 +98,6 @@ uint8_t MD_DS3231::readDevice(uint8_t addr, uint8_t* buf, uint8_t len)
   return(len);
 }
 
-ATTR_USE
 uint8_t MD_DS3231::writeDevice(uint8_t addr, uint8_t* buf, uint8_t len)
 {
   Wire.beginTransmission(DS3231_ID);
@@ -119,7 +109,6 @@ uint8_t MD_DS3231::writeDevice(uint8_t addr, uint8_t* buf, uint8_t len)
 }
 
 // Class functions
-ATTR_USE
 MD_DS3231::MD_DS3231() : yyyy(0), mm(0), dd(0), h(0), m(0), s(0), 
 #if ENABLE_DOW
 dow(0),
@@ -146,7 +135,6 @@ _cbAlarm1(nullptr), _cbAlarm2(nullptr)
 }
 #endif
 
-ATTR_USE
 boolean MD_DS3231::checkAlarm1(void)
 // Check the alarm. If time happened then call the callback function and reset the flag
 {
@@ -161,7 +149,6 @@ boolean MD_DS3231::checkAlarm1(void)
   return(b);
 }
 
-ATTR_USE
 boolean MD_DS3231::checkAlarm2(void)
 // Check the alarm. If time happened then call the callback function and reset the flag
 {
@@ -176,7 +163,6 @@ boolean MD_DS3231::checkAlarm2(void)
   return(b);
 }
 
-ATTR_USE
 boolean MD_DS3231::setAlarm1Type(almType_t almType)
 {
   // read the current data into the buffer
@@ -194,7 +180,6 @@ boolean MD_DS3231::setAlarm1Type(almType_t almType)
   return(writeDevice(ADDR_ALM1, bufRTC, 4) == 4);
 }
 
-ATTR_USE
 almType_t MD_DS3231::getAlarm1Type(void)
 {
   // read the current data into the buffer
@@ -210,7 +195,6 @@ almType_t MD_DS3231::getAlarm1Type(void)
   return static_cast<almType_t>(m);  
 }
 
-ATTR_USE
 boolean MD_DS3231::setAlarm2Type(almType_t almType)
 {
   // read the current data into the buffer
@@ -228,7 +212,6 @@ boolean MD_DS3231::setAlarm2Type(almType_t almType)
   return(writeDevice(ADDR_ALM2, bufRTC, 3) == 3);  
 }
 
-ATTR_USE
 almType_t MD_DS3231::getAlarm2Type(void)
 {
   // read the current data into the buffer
@@ -244,7 +227,6 @@ almType_t MD_DS3231::getAlarm2Type(void)
   return static_cast<almType_t>(m | 0x40); //alarm2 types have the sixth bit set
 }
 
-ATTR_USE
 boolean MD_DS3231::unpackAlarm(uint8_t entryPoint)
 // general routine for unpacking alarm registers from device
 // Assumes the buffer is set up as per Alarm 1 registers. For Alarm 2 (missing seconds), 
@@ -284,7 +266,6 @@ boolean MD_DS3231::unpackAlarm(uint8_t entryPoint)
   return(true);
 }
 
-ATTR_USE
 boolean MD_DS3231::readAlarm1(void)
 // Read the current time from the RTC and unpack it into the object variables
 // return true if the function succeeded
@@ -295,7 +276,6 @@ boolean MD_DS3231::readAlarm1(void)
   return(true);
 }
 
-ATTR_USE
 boolean MD_DS3231::readAlarm2(void)
 // Read the current time from the RTC and unpack it into the object variables
 // return true if the function succeeded
@@ -306,7 +286,6 @@ boolean MD_DS3231::readAlarm2(void)
   return(true);
 }
 
-ATTR_USE
 boolean MD_DS3231::readTime(void)
 // Read the current time from the RTC and unpack it into the object variables
 // return true if the function succeeded
@@ -343,7 +322,6 @@ boolean MD_DS3231::readTime(void)
   return(true);
 }
 
-ATTR_USE
 boolean MD_DS3231::packAlarm(uint8_t entryPoint)
 {
 #if ENABLE_12H
@@ -388,7 +366,6 @@ boolean MD_DS3231::packAlarm(uint8_t entryPoint)
     return(true);
 }
 
-ATTR_USE
 boolean MD_DS3231::writeAlarm1(almType_t almType)
 {
   packAlarm(1);
@@ -397,7 +374,6 @@ boolean MD_DS3231::writeAlarm1(almType_t almType)
   return(setAlarm1Type(almType));
 }
 
-ATTR_USE
 boolean MD_DS3231::writeAlarm2(almType_t almType)
 {
   packAlarm(2);
@@ -406,7 +382,6 @@ boolean MD_DS3231::writeAlarm2(almType_t almType)
   return(setAlarm2Type(almType));
 }
 
-ATTR_USE
 boolean MD_DS3231::writeTime(void)
 // Pack up and write the time stored in the object variables to the RTC
 // Note: Setting the time will also start the clock of it is halted
@@ -449,7 +424,6 @@ boolean MD_DS3231::writeTime(void)
   return(writeDevice(ADDR_TIME, bufRTC, 7) == 7);
 }
 
-ATTR_USE
 uint8_t MD_DS3231::readRAM(uint8_t addr, uint8_t* buf, uint8_t len)
 // Read len bytes from the RTC, starting at address addr, and put them in buf
 // Reading includes all bytes at addresses RAM_BASE_READ to DS3231_RAM_MAX
@@ -463,7 +437,6 @@ uint8_t MD_DS3231::readRAM(uint8_t addr, uint8_t* buf, uint8_t len)
   return(readDevice(addr, buf, len));   // read all the data once
 }
 
-ATTR_USE
 uint8_t MD_DS3231::writeRAM(uint8_t addr, uint8_t* buf, uint8_t len)
 // Write len bytes from buffer buf to the RTC, starting at address addr
 // Writing includes all bytes at addresses RAM_BASE_READ to DS3231_RAM_MAX
@@ -475,7 +448,6 @@ uint8_t MD_DS3231::writeRAM(uint8_t addr, uint8_t* buf, uint8_t len)
   return(writeDevice(addr, buf, len));	// write all the data at once
 }
 
-ATTR_USE
 uint8_t MD_DS3231::calcDoW(uint16_t yyyy, uint8_t mm, uint8_t dd) 
 // https://en.wikipedia.org/wiki/Determination_of_the_day_of_the_week
 // This algorithm good for dates  yyyy > 1752 and  1 <= mm <= 12
@@ -489,7 +461,6 @@ uint8_t MD_DS3231::calcDoW(uint16_t yyyy, uint8_t mm, uint8_t dd)
   return ((yyyy + yyyy/4 - yyyy/100 + yyyy/400 + t + dd) % 7) + 1;
 }
 
-ATTR_USE
 float MD_DS3231::readTempRegister()
 {
   if (readDevice(ADDR_TEMP_REGISTER, bufRTC, 2) != 2)
@@ -498,7 +469,6 @@ float MD_DS3231::readTempRegister()
   return(bufRTC[0] + ((bufRTC[1] >> 6) * 0.25));
 }
 
-ATTR_USE
 boolean MD_DS3231::control(codeRequest_t item, uint8_t value)
 // Perform a control action on item, using the value
 {
@@ -681,7 +651,6 @@ boolean MD_DS3231::control(codeRequest_t item, uint8_t value)
   return(writeDevice(addr, bufRTC, 1) == 1);
 }
 
-ATTR_USE
 codeStatus_t MD_DS3231::status(codeRequest_t item)
 // Obtain the status of the controllable item and return it.
 // Return DS3231_ERROR otherwise.
@@ -730,5 +699,3 @@ codeStatus_t MD_DS3231::status(codeRequest_t item)
   // any other parameters are single bit ON of OFF
   return((bufRTC[0] & mask) ? DS3231_ON : DS3231_OFF);
 }
-
-#pragma GGC pop_options

--- a/src/MD_DS3231.cpp
+++ b/src/MD_DS3231.cpp
@@ -233,6 +233,7 @@ boolean MD_DS3231::unpackAlarm(uint8_t entryPoint)
       
     case 2:   // Alarm 1 and Alarm 2 registers
       m = BCD2bin(bufRTC[ADDR_MIN]);
+#if ENABLE_12H
       if (bufRTC[ADDR_CTL_12H] & CTL_12H)     // 12 hour clock
       {
         h = BCD2bin(bufRTC[ADDR_HR] & 0x1f);
@@ -240,10 +241,12 @@ boolean MD_DS3231::unpackAlarm(uint8_t entryPoint)
       } 
       else
       {
+#endif
         h = BCD2bin(bufRTC[ADDR_HR] & 0x3f);
+#if ENABLE_12H
         pm = 0;
       }
-      
+#endif      
       if (bufRTC[ADDR_CTL_DYDT] & CTL_DYDT)   // Day or date?
       {
         dow = BCD2bin(bufRTC[ADDR_DAY] & 0x0f);
@@ -289,6 +292,7 @@ boolean MD_DS3231::readTime(void)
   // unpack it
   s = BCD2bin(bufRTC[ADDR_SEC]);
   m = BCD2bin(bufRTC[ADDR_MIN]);
+#if ENABLE_12H
   if (bufRTC[ADDR_CTL_12H] & CTL_12H) // 12 hour clock
   {
     h = BCD2bin(bufRTC[ADDR_HR] & 0x1f);
@@ -296,9 +300,12 @@ boolean MD_DS3231::readTime(void)
   }
   else
   {
+#endif
     h = BCD2bin(bufRTC[ADDR_HR] & 0x3f);
+#if ENABLE_12H
     pm = 0;
   }
+#endif
   dow = BCD2bin(bufRTC[ADDR_DAY]);
   dd = BCD2bin(bufRTC[ADDR_TDATE]);
   mm = BCD2bin(bufRTC[ADDR_MON]);
@@ -312,7 +319,9 @@ boolean MD_DS3231::readTime(void)
 ATTR_USE
 boolean MD_DS3231::packAlarm(uint8_t entryPoint)
 {
+#if ENABLE_12H
     boolean mode12 = (status(DS3231_12H) == DS3231_ON);
+#endif
 
     CLEAR_BUFFER;
     
@@ -325,6 +334,7 @@ boolean MD_DS3231::packAlarm(uint8_t entryPoint)
         
       case 2:
         bufRTC[ADDR_MIN] = bin2BCD(m);
+#if ENABLE_12H
         if (mode12)     // 12 hour clock
         {
           uint8_t	hour = bin2BCD(h);
@@ -336,6 +346,7 @@ boolean MD_DS3231::packAlarm(uint8_t entryPoint)
           bufRTC[ADDR_CTL_12H] |= CTL_12H;
         }
         else
+#endif        
           bufRTC[ADDR_HR] = bin2BCD(h);
 
         if (dow == 0) // signal that this is a date, not day
@@ -377,13 +388,15 @@ boolean MD_DS3231::writeTime(void)
 // Note: Setting the time will also start the clock of it is halted
 // return true if the function succeeded
 {
+#if ENABLE_12H
   boolean mode12 = (status(DS3231_12H) == DS3231_ON);
-  
+#endif  
   CLEAR_BUFFER;
   
   // pack it up in the current space
   bufRTC[ADDR_SEC] = bin2BCD(s);
   bufRTC[ADDR_MIN] = bin2BCD(m);
+#if ENABLE_12H
   if (mode12)     // 12 hour clock
   {
     pm = (h > 12);
@@ -393,6 +406,7 @@ boolean MD_DS3231::writeTime(void)
     bufRTC[ADDR_CTL_12H] |= CTL_12H;
   }
   else
+#endif
     bufRTC[ADDR_HR] = bin2BCD(h);
     
   bufRTC[ADDR_DAY] = bin2BCD(dow);
@@ -604,6 +618,7 @@ boolean MD_DS3231::control(codeRequest_t item, uint8_t value)
   if (readDevice(addr, bufRTC, 1) != 1)
     return(false);
 
+#if ENABLE_12H
   // do any special processing here
   if (item == DS3231_12H)   // changing 12/24H clock - special handling of hours conversion
   {
@@ -631,6 +646,7 @@ boolean MD_DS3231::control(codeRequest_t item, uint8_t value)
       break;
     }
   }
+#endif
 
   // Mask off the new status, set the value and then write it back
   bufRTC[0] &= ~mask;

--- a/src/MD_DS3231.cpp
+++ b/src/MD_DS3231.cpp
@@ -178,10 +178,9 @@ almType_t MD_DS3231::getAlarm1Type(void)
 
   // create a value with bit 0=M1, 1=M2, 2=M3, 3=M4, 4=D
   uint16_t m = 0;
-  m |= (bufRTC[0] & 0x80) >> 7;
-  m |= (bufRTC[1] & 0x80) >> 6;
-  m |= (bufRTC[2] & 0x80) >> 5;
-  m |= (bufRTC[3] & 0x80) >> 4;
+  for(uint8_t i = 0; i < 4; i++) {
+    m |= (bufRTC[i] & 0x80) >> (7 - i);  
+  }
   m |= (bufRTC[3] & 0x40) >> 2;
 
   return static_cast<almType_t>(m);  
@@ -211,9 +210,9 @@ almType_t MD_DS3231::getAlarm2Type(void)
 
   // create a value with bit 0=M2, 2=M3, 3=M4
   uint8_t m = 0;
-  m |= (bufRTC[0] & 0x80) >> 7;
-  m |= (bufRTC[1] & 0x80) >> 6;
-  m |= (bufRTC[2] & 0x80) >> 5;
+  for(uint8_t i = 0; i < 3; i++) {
+    m |= (bufRTC[i] & 0x80) >> (7 - i);  
+  }
   m |= (bufRTC[2] & 0x40) >> 3;
 
   return static_cast<almType_t>(m | 0x40); //alarm2 types have the sixth bit set

--- a/src/MD_DS3231.cpp
+++ b/src/MD_DS3231.cpp
@@ -11,6 +11,14 @@
 #include <Wire.h>
 #include "MD_DS3231.h"
 
+#pragma GGC push_options
+
+#pragma GCC optimize ("no-dce")
+#pragma GCC optimize ("no-tree-dce")
+#define ATTR_USE __attribute__ ((used))
+
+// #define ATTR_USE
+
 class MD_DS3231 RTC;  // one instance created when library is included
 
 // Useful definitions
@@ -70,6 +78,7 @@ uint8_t bufRTC[MAX_BUF];
 #define CLEAR_BUFFER  { memset(bufRTC, 0, sizeof(bufRTC)); }
 
 // Interface functions for the RTC device
+ATTR_USE
 uint8_t MD_DS3231::readDevice(uint8_t addr, uint8_t* buf, uint8_t len)
 {
   Wire.beginTransmission(DS3231_ID);
@@ -87,6 +96,7 @@ uint8_t MD_DS3231::readDevice(uint8_t addr, uint8_t* buf, uint8_t len)
   return(len);
 }
 
+ATTR_USE
 uint8_t MD_DS3231::writeDevice(uint8_t addr, uint8_t* buf, uint8_t len)
 {
   Wire.beginTransmission(DS3231_ID);
@@ -101,6 +111,7 @@ uint8_t MD_DS3231::writeDevice(uint8_t addr, uint8_t* buf, uint8_t len)
 }
 
 // Class functions
+ATTR_USE
 MD_DS3231::MD_DS3231() : yyyy(0), mm(0), dd(0), h(0), m(0), s(0), dow(0),
 _cbAlarm1(nullptr), _cbAlarm2(nullptr), _century(20)
 {
@@ -115,6 +126,7 @@ _cbAlarm1(nullptr), _cbAlarm2(nullptr), _century(20)
 }
 #endif
 
+ATTR_USE
 boolean MD_DS3231::checkAlarm1(void)
 // Check the alarm. If time happened then call the callback function and reset the flag
 {
@@ -129,6 +141,7 @@ boolean MD_DS3231::checkAlarm1(void)
   return(b);
 }
 
+ATTR_USE
 boolean MD_DS3231::checkAlarm2(void)
 // Check the alarm. If time happened then call the callback function and reset the flag
 {
@@ -143,6 +156,7 @@ boolean MD_DS3231::checkAlarm2(void)
   return(b);
 }
 
+ATTR_USE
 boolean MD_DS3231::setAlarm1Type(almType_t almType)
 {
   uint8_t m1, m2, m3, m4, d; // A1M1, A1M2, A1M3, A1M4, DY/~DT
@@ -171,6 +185,7 @@ boolean MD_DS3231::setAlarm1Type(almType_t almType)
   return(writeDevice(ADDR_ALM1, bufRTC, 4) == 4);
 }
 
+ATTR_USE
 almType_t MD_DS3231::getAlarm1Type(void)
 {
   uint8_t m = 0;
@@ -200,6 +215,7 @@ almType_t MD_DS3231::getAlarm1Type(void)
   return(DS3231_ALM_ERROR);
 }
 
+ATTR_USE
 boolean MD_DS3231::setAlarm2Type(almType_t almType)
 {
   uint8_t m2, m3, m4, d; // A2M2, A2M3, A2M4, DY/~DT
@@ -226,6 +242,7 @@ boolean MD_DS3231::setAlarm2Type(almType_t almType)
   return(writeDevice(ADDR_ALM2, bufRTC, 3) == 3);  
 }
 
+ATTR_USE
 almType_t MD_DS3231::getAlarm2Type(void)
 {
   uint8_t m = 0;
@@ -253,6 +270,7 @@ almType_t MD_DS3231::getAlarm2Type(void)
   return(DS3231_ALM_ERROR);
 }
 
+ATTR_USE
 boolean MD_DS3231::unpackAlarm(uint8_t entryPoint)
 // general routine for unpacking alarm registers from device
 // Assumes the buffer is set up as per Alarm 1 registers. For Alarm 2 (missing seconds), 
@@ -290,6 +308,7 @@ boolean MD_DS3231::unpackAlarm(uint8_t entryPoint)
   return(true);
 }
 
+ATTR_USE
 boolean MD_DS3231::readAlarm1(void)
 // Read the current time from the RTC and unpack it into the object variables
 // return true if the function succeeded
@@ -300,6 +319,7 @@ boolean MD_DS3231::readAlarm1(void)
   return(true);
 }
 
+ATTR_USE
 boolean MD_DS3231::readAlarm2(void)
 // Read the current time from the RTC and unpack it into the object variables
 // return true if the function succeeded
@@ -310,6 +330,7 @@ boolean MD_DS3231::readAlarm2(void)
   return(true);
 }
 
+ATTR_USE
 boolean MD_DS3231::readTime(void)
 // Read the current time from the RTC and unpack it into the object variables
 // return true if the function succeeded
@@ -339,6 +360,7 @@ boolean MD_DS3231::readTime(void)
   return(true);
 }
 
+ATTR_USE
 boolean MD_DS3231::packAlarm(uint8_t entryPoint)
 {
     boolean mode12 = (status(DS3231_12H) == DS3231_ON);
@@ -382,6 +404,7 @@ boolean MD_DS3231::packAlarm(uint8_t entryPoint)
     return(true);
 }
 
+ATTR_USE
 boolean MD_DS3231::writeAlarm1(almType_t almType)
 {
   packAlarm(1);
@@ -390,6 +413,7 @@ boolean MD_DS3231::writeAlarm1(almType_t almType)
   return(setAlarm1Type(almType));
 }
 
+ATTR_USE
 boolean MD_DS3231::writeAlarm2(almType_t almType)
 {
   packAlarm(2);
@@ -398,6 +422,7 @@ boolean MD_DS3231::writeAlarm2(almType_t almType)
   return(setAlarm2Type(almType));
 }
 
+ATTR_USE
 boolean MD_DS3231::writeTime(void)
 // Pack up and write the time stored in the object variables to the RTC
 // Note: Setting the time will also start the clock of it is halted
@@ -434,6 +459,7 @@ boolean MD_DS3231::writeTime(void)
   return(writeDevice(ADDR_TIME, bufRTC, 7) == 7);
 }
 
+ATTR_USE
 uint8_t MD_DS3231::readRAM(uint8_t addr, uint8_t* buf, uint8_t len)
 // Read len bytes from the RTC, starting at address addr, and put them in buf
 // Reading includes all bytes at addresses RAM_BASE_READ to DS3231_RAM_MAX
@@ -447,6 +473,7 @@ uint8_t MD_DS3231::readRAM(uint8_t addr, uint8_t* buf, uint8_t len)
   return(readDevice(addr, buf, len));   // read all the data once
 }
 
+ATTR_USE
 uint8_t MD_DS3231::writeRAM(uint8_t addr, uint8_t* buf, uint8_t len)
 // Write len bytes from buffer buf to the RTC, starting at address addr
 // Writing includes all bytes at addresses RAM_BASE_READ to DS3231_RAM_MAX
@@ -458,6 +485,7 @@ uint8_t MD_DS3231::writeRAM(uint8_t addr, uint8_t* buf, uint8_t len)
   return(writeDevice(addr, buf, len));	// write all the data at once
 }
 
+ATTR_USE
 uint8_t MD_DS3231::calcDoW(uint16_t yyyy, uint8_t mm, uint8_t dd) 
 // https://en.wikipedia.org/wiki/Determination_of_the_day_of_the_week
 // This algorithm good for dates  yyyy > 1752 and  1 <= mm <= 12
@@ -470,6 +498,7 @@ uint8_t MD_DS3231::calcDoW(uint16_t yyyy, uint8_t mm, uint8_t dd)
 }
 
 #if ENABLE_TEMP_COMP
+ATTR_USE
 float MD_DS3231::readTempRegister()
 {
   if (readDevice(ADDR_TEMP_REGISTER, bufRTC, 2) != 2)
@@ -479,6 +508,7 @@ float MD_DS3231::readTempRegister()
 }
 #endif
 
+ATTR_USE
 boolean MD_DS3231::control(codeRequest_t item, uint8_t value)
 // Perform a control action on item, using the value
 {
@@ -659,6 +689,7 @@ boolean MD_DS3231::control(codeRequest_t item, uint8_t value)
   return(writeDevice(addr, bufRTC, 1) == 1);
 }
 
+ATTR_USE
 codeStatus_t MD_DS3231::status(codeRequest_t item)
 // Obtain the status of the controllable item and return it.
 // Return DS3231_ERROR otherwise.
@@ -707,3 +738,5 @@ codeStatus_t MD_DS3231::status(codeRequest_t item)
   // any other parameters are single bit ON of OFF
   return((bufRTC[0] & mask) ? DS3231_ON : DS3231_OFF);
 }
+
+#pragma GGC pop_options

--- a/src/MD_DS3231.cpp
+++ b/src/MD_DS3231.cpp
@@ -24,7 +24,7 @@ class MD_DS3231 RTC;  // one instance created when library is included
 #endif
 
 // Useful definitions
-#define DS3231_ID 0x68  // I2C/TWI device address, coded into the device
+#define DS3231_ID ((uint8_t)0x68)  // I2C/TWI device address, coded into the device
 
 #define RAM_BASE_READ 0 // smallest read address
 
@@ -97,7 +97,7 @@ uint8_t MD_DS3231::readDevice(uint8_t addr, uint8_t* buf, uint8_t len)
   if (Wire.endTransmission() != 0)
     return(0);
 
-  Wire.requestFrom(DS3231_ID, (int)len);
+  Wire.requestFrom(DS3231_ID, len);
   //while (!Wire.available()) ;   // wait
   for (uint8_t i=0; i<len; i++) // Read x data from given address upwards...
   {

--- a/src/MD_DS3231.h
+++ b/src/MD_DS3231.h
@@ -178,6 +178,10 @@ The DS3231_LCD_Time example has examples of the different ways of interacting wi
  AMP/PM, disabling 12H support migh give back up to 340 bytes on 
  the final HEX size. Note that if diabled, you should call
  control(DS3231_12H, DS3231_OFF) right after device initialization.
+
+ You can change the default by editing this file directly or using a command
+ line tool like sed :
+ sed "s/^#define ENABLE_12H 1/#define ENABLE_12H 0/" -i MD_DS3231.h
  */
 #define ENABLE_12H 1  ///< Enable 12H (AMP/PM) support
 
@@ -187,6 +191,10 @@ The DS3231_LCD_Time example has examples of the different ways of interacting wi
  code cannot be omitted by GCC optimization so disabling day of
  week support if you're not using it might give back up to 212 bytes on
  the final HEX size.
+
+ You can change the default by editing this file directly or using a command
+ line tool like sed :
+ sed "s/^#define ENABLE_DOW 1/#define ENABLE_DOW 0/" -i MD_DS3231.h
  */
 #define ENABLE_DOW 1 ///< Enable Day of Week vs Date support
 

--- a/src/MD_DS3231.h
+++ b/src/MD_DS3231.h
@@ -309,7 +309,7 @@ enum codeStatus_t
   */
 enum almType_t
 {
- DS3231_ALM_ERROR   = -1,         ///< An error occurred executing the requested action
+ DS3231_ALM_ERROR   = -1,             ///< An error occurred executing the requested action
  DS3231_ALM_SEC     = 0b00001111,     ///< Alarm once per second (alm 1 only)
  DS3231_ALM_S       = 0b00001110,     ///< Alarm when seconds match (alm 1 only)
  DS3231_ALM_MIN     = 0b01000111,     ///< Alarm once per minute (alm 2 only)
@@ -318,9 +318,9 @@ enum almType_t
  DS3231_ALM_HM      = 0b01000100,     ///< Alarm when hours and minutes match (alm 2 only)
  DS3231_ALM_HMS     = 0b00001000,     ///< Alarm when hours, minutes and seconds match (alm 1 only)
  DS3231_ALM_DTHM    = 0b01000000,     ///< Alarm when date, hours and minutes match (alm 2 only)
- DS3231_ALM_DTHMS   = 0b00000000,    ///< Alarm when date, hours, minutes and seconds match (alm 1 only)
+ DS3231_ALM_DTHMS   = 0b00000000,     ///< Alarm when date, hours, minutes and seconds match (alm 1 only)
  DS3231_ALM_DDHM    = 0b01001000,     ///< Alarm when day, hours and minutes match (alm 2 only)
- DS3231_ALM_DDHMS   = 0b00010000,   ///< Alarm when day, hours, minutes and seconds match (alm 1 only)
+ DS3231_ALM_DDHMS   = 0b00010000,     ///< Alarm when day, hours, minutes and seconds match (alm 1 only)
 };
 
 /**

--- a/src/MD_DS3231.h
+++ b/src/MD_DS3231.h
@@ -172,6 +172,15 @@ The DS3231_LCD_Time example has examples of the different ways of interacting wi
  */
 
 /**
+ \def ENABLE_12H
+ Set to 1 (default) to enable the AM/PM support. The related
+ code cannot be omitted by GCC optimization so if you're not using 
+ AMP/PM, disabling 12H support migh give back up to 340 bytes on 
+ the final HEX size. Note that if diabled, you should call
+ control(DS3231_12H, DS3231_OFF) right after device initialization.
+ */
+#define ENABLE_12H 1  ///< Enable 12H (AMP/PM) support
+/**
  \def ENABLE_TEMP_COMP
  Set to 1 (default) to enable the temperature comparator related
  functions. The temperature is returned as a floating point number -
@@ -663,7 +672,9 @@ class MD_DS3231
   uint8_t m;    ///< Minutes past the hour (0-59)
   uint8_t s;    ///< Seconds past the minute (0-59)
   uint8_t dow;  ///< Day of the week (1-7). Sequential number; day coding depends on the application and zero is an undefined value
+  #if ENABLE_12H
   uint8_t pm;   ///< Non-zero if 12 hour clock mode and PM, always zero for 24 hour clock. Check the time and if < 12 then check this indicator.
+  #endif
 
   /** @} */
 

--- a/src/MD_DS3231.h
+++ b/src/MD_DS3231.h
@@ -253,20 +253,20 @@ enum codeStatus_t
   * This enumerated type is used to set and inspect the alarm types
    * for Alarms 1 and 2 using the setAlarmType() and getAlarmType() methods.
   */
-enum almType_t 
+enum almType_t
 {
- DS3231_ALM_ERROR,   ///< An error occurred executing the requested action
- DS3231_ALM_SEC,     ///< Alarm once per second (alm 1 only)
- DS3231_ALM_S,       ///< Alarm when seconds match (alm 1 only)
- DS3231_ALM_MIN,     ///< Alarm once per minute (alm 2 only)
- DS3231_ALM_M,       ///< Alarm when minutes match (alm 2 only)
- DS3231_ALM_MS,      ///< Alarm when minutes and seconds match (alm 1 only)
- DS3231_ALM_HM,      ///< Alarm when hours and minutes match (alm 2 only)
- DS3231_ALM_HMS,     ///< Alarm when hours, minutes and seconds match (alm 1 only)
- DS3231_ALM_DTHM,    ///< Alarm when date, hours and minutes match (alm 2 only)
- DS3231_ALM_DTHMS,   ///< Alarm when date, hours, minutes and seconds match (alm 1 only)
- DS3231_ALM_DDHM,    ///< Alarm when day, hours and minutes match (alm 2 only)
- DS3231_ALM_DDHMS,   ///< Alarm when day, hours, minutes and seconds match (alm 1 only)
+ DS3231_ALM_ERROR   = -1,         ///< An error occurred executing the requested action
+ DS3231_ALM_SEC     = 0b00001111,     ///< Alarm once per second (alm 1 only)
+ DS3231_ALM_S       = 0b00001110,     ///< Alarm when seconds match (alm 1 only)
+ DS3231_ALM_MIN     = 0b01000111,     ///< Alarm once per minute (alm 2 only)
+ DS3231_ALM_M       = 0b01000110,     ///< Alarm when minutes match (alm 2 only)
+ DS3231_ALM_MS      = 0b00001100,     ///< Alarm when minutes and seconds match (alm 1 only)
+ DS3231_ALM_HM      = 0b01000100,     ///< Alarm when hours and minutes match (alm 2 only)
+ DS3231_ALM_HMS     = 0b00001000,     ///< Alarm when hours, minutes and seconds match (alm 1 only)
+ DS3231_ALM_DTHM    = 0b01000000,     ///< Alarm when date, hours and minutes match (alm 2 only)
+ DS3231_ALM_DTHMS   = 0b00000000,    ///< Alarm when date, hours, minutes and seconds match (alm 1 only)
+ DS3231_ALM_DDHM    = 0b01001000,     ///< Alarm when day, hours and minutes match (alm 2 only)
+ DS3231_ALM_DDHMS   = 0b00010000,   ///< Alarm when day, hours, minutes and seconds match (alm 1 only)
 };
 
 /**

--- a/src/MD_DS3231.h
+++ b/src/MD_DS3231.h
@@ -180,13 +180,6 @@ The DS3231_LCD_Time example has examples of the different ways of interacting wi
  control(DS3231_12H, DS3231_OFF) right after device initialization.
  */
 #define ENABLE_12H 1  ///< Enable 12H (AMP/PM) support
-/**
- \def ENABLE_TEMP_COMP
- Set to 1 (default) to enable the temperature comparator related
- functions. The temperature is returned as a floating point number -
- excluding the function(s) may provide some memory gains.
- */
-#define ENABLE_TEMP_COMP  1   ///< Enable temperature compensation functions
 
 /**
   Control and Status Request enumerated type.
@@ -648,7 +641,6 @@ class MD_DS3231
   */
   uint8_t calcDoW(uint16_t yyyy, uint8_t mm, uint8_t dd);
 
-#if ENABLE_TEMP_COMP
  /**
   * Read the temperature register in the RTC
   *
@@ -658,7 +650,6 @@ class MD_DS3231
   * \return the temperature in degrees C.
   */
   float readTempRegister(void);
-#endif
  /** @} */
 
  //--------------------------------------------------------------

--- a/src/MD_DS3231.h
+++ b/src/MD_DS3231.h
@@ -172,41 +172,64 @@ The DS3231_LCD_Time example has examples of the different ways of interacting wi
  */
 
 /**
- \def ENABLE_12H
- Set to 1 (default) to enable the AM/PM support. The related
- code cannot be omitted by GCC optimization so if you're not using 
- AMP/PM, disabling 12H support migh give back up to 340 bytes on 
- the final HEX size. Note that if diabled, you should call
- control(DS3231_12H, DS3231_OFF) right after device initialization.
-
- You can change the default by editing this file directly or using a command
- line tool like sed :
- sed "s/^#define ENABLE_12H 1/#define ENABLE_12H 0/" -i MD_DS3231.h
+ * \def ENABLE_12H
+ * Set to 1 (default) to enable the AM/PM support. The related
+ * code cannot be omitted by GCC optimization so if you're not using 
+ * AMP/PM, disabling 12H support migh give back up to 340 bytes on 
+ * the final HEX size. Note that if diabled, you should call
+ * control(DS3231_12H, DS3231_OFF) right after device initialization.
+ * 
+ * You can change the default by editing this file directly or using a command
+ * line tool like sed :
+ * sed "s/^#define ENABLE_12H 1/#define ENABLE_12H 0/" -i MD_DS3231.h
  */
 #define ENABLE_12H 1  ///< Enable 12H (AMP/PM) support
 
 /**
- \def ENABLE_DOW
- Set to 1 (default) to enable Day of Week support. The related
- code cannot be omitted by GCC optimization so disabling day of
- week support if you're not using it might give back up to 212 bytes on
- the final HEX size.
-
- You can change the default by editing this file directly or using a command
- line tool like sed :
- sed "s/^#define ENABLE_DOW 1/#define ENABLE_DOW 0/" -i MD_DS3231.h
+ * \def ENABLE_DOW
+ * Set to 1 (default) to enable Day of Week support. The related
+ * code cannot be omitted by GCC optimization so disabling day of
+ * week support if you're not using it might give back up to 212 bytes on
+ * the final HEX size.
+ *
+ * You can change the default by editing this file directly or using a command
+ * line tool like sed :
+ * sed "s/^#define ENABLE_DOW 1/#define ENABLE_DOW 0/" -i MD_DS3231.h
  */
 #define ENABLE_DOW 1 ///< Enable Day of Week vs Date support
 
 /**
- \def ENABLE_RTC_INSTANCE
- Set to 1 (default) to create a default instance when the library is included.
- It can be useful if you want to extend the MD_DS3231 class without wasting
- space (around 60 bytes) because of a variable declaration you do not use.
+ * \def ENABLE_DYNAMIC_CENTURY
+ * Set to 1 (default) to enable support for dynamic centuries using the setCentury()
+ * and getCentury() methods. 
+ * If disabled, century is hardcoded (via DEFAULT_CENTURY) to 20 which allow working 
+ * with dates from 2000 to 2199.
+ * 
+ * You can disable this to gain 10 bytes of HEX and 2 bytes of RAM. It is only
+ * needed for backward compatility, or if you need to work with dynamic centuries.
+ *
+ * You can change the default by editing this file directly or using a command
+ * line tool like sed :
+ * sed "s/^#define ENABLE_CENTURY 1/#define ENABLE_CENTURY 0/" -i MD_DS3231.h
+ * 
+ * \sa setCentury() method
+ * \sa getCentury() method
+ * \sa DEFAULT_CENTURY
+ */
+#define ENABLE_DYNAMIC_CENTURY 1 ///< Enable support for dynamic century
 
- You can change the default by editing this file directly or using a command
- line tool like sed :
- sed "s/^#define ENABLE_RTC_INSTANCE 1/#define ENABLE_RTC_INSTANCE 0/" -i MD_DS3231.h
+/**
+ * \def ENABLE_RTC_INSTANCE
+ * Set to 1 (default) to create a default instance when the library is included.
+ * It can be useful if you want to extend the MD_DS3231 class without wasting
+ * space (around 60 bytes) because of a variable declaration you do not use.
+ *
+ * You can change the default by editing this file directly or using a command
+ * line tool like sed :
+ * sed "s/^#define ENABLE_RTC_INSTANCE 1/#define ENABLE_RTC_INSTANCE 0/" -i MD_DS3231.h
+ *
+ * \sa setCentury() method.
+ *
  */
 #define ENABLE_RTC_INSTANCE 1 ///< Enable default RTC instance creation
 
@@ -408,7 +431,9 @@ class MD_DS3231
   * \param   c the year base century. Dates will start from (c*100).
   * \return false if errors, true otherwise.
   */
+#if ENABLE_DYNAMIC_CENTURY
   inline boolean setCentury(uint8_t c) { _century = c; return(true); };
+#endif
 
  /**
   * Get the current century for year handling in the library
@@ -419,7 +444,9 @@ class MD_DS3231
   *
   * \return the year base century.
   */
+#if ENABLE_DYNAMIC_CENTURY
   inline uint8_t getCentury(void) { return(_century); };
+#endif
 
  /**
   * Compatibility function - Read the current time
@@ -703,7 +730,9 @@ class MD_DS3231
 private:
   void (*_cbAlarm1)(void);
   void (*_cbAlarm2)(void);
+#if ENABLE_DYNAMIC_CENTURY  
   uint8_t _century;
+#endif
 
   // BCD to binary number packing/unpacking functions
   inline uint8_t BCD2bin(uint8_t v) { return v - 6 * (v >> 4); }

--- a/src/MD_DS3231.h
+++ b/src/MD_DS3231.h
@@ -182,6 +182,15 @@ The DS3231_LCD_Time example has examples of the different ways of interacting wi
 #define ENABLE_12H 1  ///< Enable 12H (AMP/PM) support
 
 /**
+ \def ENABLE_DOW
+ Set to 1 (default) to enable Day of Week support. The related
+ code cannot be omitted by GCC optimization so disabling day of
+ week support if you're not using it might give back up to 212 bytes on
+ the final HEX size.
+ */
+#define ENABLE_DOW 1 ///< Enable Day of Week vs Date support
+
+/**
   Control and Status Request enumerated type.
   *
   * This enumerated type is used with the control() and status() methods to identify 
@@ -662,7 +671,9 @@ class MD_DS3231
   uint8_t h;    ///< Hour of the day (1-12) or (0-23) depending on the am/pm or 24h mode setting
   uint8_t m;    ///< Minutes past the hour (0-59)
   uint8_t s;    ///< Seconds past the minute (0-59)
+  #if ENABLE_DOW
   uint8_t dow;  ///< Day of the week (1-7). Sequential number; day coding depends on the application and zero is an undefined value
+  #endif
   #if ENABLE_12H
   uint8_t pm;   ///< Non-zero if 12 hour clock mode and PM, always zero for 24 hour clock. Check the time and if < 12 then check this indicator.
   #endif

--- a/src/MD_DS3231.h
+++ b/src/MD_DS3231.h
@@ -199,6 +199,18 @@ The DS3231_LCD_Time example has examples of the different ways of interacting wi
 #define ENABLE_DOW 1 ///< Enable Day of Week vs Date support
 
 /**
+ \def ENABLE_RTC_INSTANCE
+ Set to 1 (default) to create a default instance when the library is included.
+ It can be useful if you want to extend the MD_DS3231 class without wasting
+ space (around 60 bytes) because of a variable declaration you do not use.
+
+ You can change the default by editing this file directly or using a command
+ line tool like sed :
+ sed "s/^#define ENABLE_RTC_INSTANCE 1/#define ENABLE_RTC_INSTANCE 0/" -i MD_DS3231.h
+ */
+#define ENABLE_RTC_INSTANCE 1 ///< Enable default RTC instance creation
+
+/**
   Control and Status Request enumerated type.
   *
   * This enumerated type is used with the control() and status() methods to identify 
@@ -704,6 +716,8 @@ private:
   uint8_t writeDevice(uint8_t addr, uint8_t* buf, uint8_t len);
 };
 
+#if ENABLE_RTC_INSTANCE
 extern MD_DS3231 RTC;    ///< Library created instance of the RTC class
+#endif
 
 #endif


### PR DESCRIPTION
Hi (again),

Note : this pull request *will* conflict with the [other one](https://github.com/MajicDesigns/MD_DS3231/pull/8) I just opened because of some whitespaces. I kept both changesets separated so you can easily discard this one if you don't like it, while retaining the bugfixes. I'll deal with the conflicts on my fork, but I opened this
PR without waiting for the other because I anticipate that wyou'll want to discuss this one :)

This pull request allow to shrink down the library size in a substantial way.
 * Around 300 bytes with all features
 * 370 additional bytes by disabling 12H clock mode
 * 84 additional bytes by disabling day of week support

Some additional changes :
 * Removed `ENABLE_TEMP_COMP` : GCC will take care of that for you. The 'flag' is wether you use the function or not
 * Added `ENABLE_CUSTOM_CENTURY` : Just here for backward compatibility, but you might as well remove *dynamic* century support from the library and rely on the define.

All the changes are backward compatibles.

As a sidenote, 150 bytes of HEX space and 7 bytes of RAM can be saved by moving the interface registers
to function parameters (using a `struct` for conviniency). That would be a breaking changes but would also
made things cleaner as there would no longer be some outdated/irrelevant data in those registers.

Here are the numbers of an empty sketch with all of `MD_DS3231` code forced included, and conditionnal features removed.

Features        | Space (bytes)         | Ram (bytes)
----------------|-----------------------|------------------
v1.2.4          | 6344                  | 265
All features    | 6066                  | 240
ENABLE_12H 0    | 5696                  | 239
ENABLE_DOW 0    | 5982                  | 239

Hope you'll like it !
Regards